### PR TITLE
Add flattening utilities for sequences and iterables.

### DIFF
--- a/src/main/kotlin/com/natpryce/flatten.kt
+++ b/src/main/kotlin/com/natpryce/flatten.kt
@@ -1,0 +1,57 @@
+package com.natpryce
+
+/**
+ * Flattens out nested sequences contained in results. For instance, if there
+ * is a sequence of open database connections that may or may not succeed in
+ * returning results and you desire them streamed together, this will enable
+ * lazy iteration over the results. Any failing results will be replaced in the
+ * sequence with the failure in the original sequence.
+ */
+fun <T, E> Sequence<Result<Sequence<T>, E>>.flatten(): Sequence<Result<T, E>> {
+    val iter = this.iterator()
+    return generateSequence {
+        if (!iter.hasNext()) {
+            // Terminate the sequence
+            return@generateSequence null
+        }
+        when (val nextResult = iter.next()) {
+            is Success -> nextResult.value.asSequence().map { Success(it) }
+            is Failure -> listOf(nextResult).asSequence()
+        }
+    }.flatten()
+}
+
+/**
+ * Flattens out a sequence of result-wrapped iterables. For instance, if there
+ * is a sequence of paging API calls being lazily iterated on, this will turn
+ * it into one seamless sequence of results, lazily evaluating each element as
+ * it's needed. Any failing results will be replaced in the sequence with the
+ * failure in the original sequence.
+ */
+@JvmName("flattenSequenceOfResultOfIterable")
+fun <T, E> Sequence<Result<Iterable<T>, E>>.flatten(): Sequence<Result<T, E>> {
+    val iter = this.iterator()
+    return generateSequence {
+        if (!iter.hasNext()) {
+            // Terminate the sequence
+            return@generateSequence null
+        }
+        when (val nextResult = iter.next()) {
+            is Success -> nextResult.value.asSequence().map { Success(it) }
+            is Failure -> listOf(nextResult).asSequence()
+        }
+    }.flatten()
+}
+
+/**
+ * Flattens out an iterable of result-wrapped iterables. Any failing results
+ * will be replaced in the sequence with the failure in the original sequence.
+ */
+fun <T, E> Iterable<Result<Iterable<T>, E>>.flatten(): Iterable<Result<T, E>> {
+    return this.map {
+        when (it) {
+            is Success -> it.value.map { s -> Success(s) }
+            is Failure -> listOf(it)
+        }
+    }.flatten()
+}

--- a/src/test/kotlin/com/natpryce/flatten_tests.kt
+++ b/src/test/kotlin/com/natpryce/flatten_tests.kt
@@ -1,0 +1,99 @@
+package com.natpryce
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class SequenceOfSequencesFlattenTests {
+    @Test
+    fun `a sequence of results of sequences returns a flattened sequence`() {
+        val unflattened = listOf(
+                Success(listOf(1, 2, 3).asSequence()),
+                Success(listOf(4, 5).asSequence()),
+                Success(listOf(6).asSequence())
+        ).asSequence()
+        assertEquals(listOf(1, 2, 3, 4, 5, 6).map { Success(it) }, unflattened.flatten().toList())
+    }
+
+    @Test
+    fun `a sequence of results of sequences returns a flattened sequence with failures`() {
+        val ex = RuntimeException()
+        val unflattened = listOf(
+                Success(listOf(1, 2, 3).asSequence()),
+                Failure(ex),
+                Success(listOf(6).asSequence())
+        ).asSequence()
+        assertEquals(listOf(Success(1), Success(2), Success(3), Failure(ex), Success(6)), unflattened.flatten().toList())
+    }
+
+    @Test
+    fun `a sequence of results of sequences is lazily evaluated`() {
+        val unflattened = listOf(
+                Success(listOf(1, 2, 3).asSequence()),
+                Failure(RuntimeException()),
+                // Would explode if run.
+                Success(listOf(6).asSequence().map { it / 0 })
+        ).asSequence()
+        assertEquals(listOf(1, 2, 3).map { Success(it) }, unflattened.flatten().takeWhile { it is Success }.toList())
+    }
+}
+
+class SequenceOfIterablesFlattenTests {
+    @Test
+    fun `a sequence of results of iterables returns a flattened sequence`() {
+        val unflattened = listOf(
+                Success(listOf(1, 2, 3)),
+                Success(listOf(4, 5)),
+                Success(listOf(6))
+        ).asSequence()
+        assertEquals(listOf(1, 2, 3, 4, 5, 6).map { Success(it) }, unflattened.flatten().toList())
+    }
+
+    @Test
+    fun `a sequence of results of iterables returns a flattened sequence with failures`() {
+        val ex = RuntimeException()
+        val unflattened = listOf(
+                Success(listOf(1, 2, 3)),
+                Failure(ex),
+                Success(listOf(6))
+        ).asSequence()
+        assertEquals(listOf(Success(1), Success(2), Success(3), Failure(ex), Success(6)), unflattened.flatten().toList())
+    }
+
+    @Test
+    fun `a sequence of results of iterables is lazily evaluated`() {
+        val ex = RuntimeException()
+        var i = 0
+        val unflattened = generateSequence {
+            i++
+            when (i) {
+                1 -> Success(listOf(1, 2, 3))
+                2 -> Failure(ex)
+                else -> throw RuntimeException("NOT LAZY")
+            }
+        }
+        assertEquals(listOf(1, 2, 3).map { Success(it) }, unflattened.flatten().takeWhile { it is Success }.toList())
+    }
+}
+
+class IterableOfIterablesFlattenTests {
+    @Test
+    fun `an iterable of results of iterables returns a flattened iterable`() {
+        val unflattened = listOf(
+                Success(listOf(1, 2, 3)),
+                Success(listOf(4, 5)),
+                Success(listOf(6))
+        )
+        assertEquals(listOf(1, 2, 3, 4, 5, 6).map { Success(it) }, unflattened.flatten())
+    }
+
+    @Test
+    fun `an iterable of results of iterables returns a flattened iterable with failures`() {
+        val ex = RuntimeException()
+        val unflattened = listOf(
+                Success(listOf(1, 2, 3)),
+                Failure(ex),
+                Success(listOf(6))
+        )
+        assertEquals<Iterable<Result<Int, Exception>>>(listOf(Success(1), Success(2), Success(3), Failure(ex), Success(6)), unflattened.flatten())
+    }
+}


### PR DESCRIPTION
In using this library to run over an paged API I found that flattening the results into a lazy sequence was exceptionally useful. Once I had written the extension method it seemed like something others might like as well. The best way to see what this is doing is to take a look at the tests, but I think the type signatures of the extension methods make it pretty clear by themselves.